### PR TITLE
add field error for same password

### DIFF
--- a/web-app/app/actions-auth.ts
+++ b/web-app/app/actions-auth.ts
@@ -116,7 +116,12 @@ export async function setPassword(
   if (updateResp.error) {
     return {
       lastInvocationStatus: "error",
-      error: { rootError: JSON.stringify(updateResp.error) },
+      error:
+        updateResp.error.code === "same_password"
+          ? {
+              fieldErrors: { password: "Must not re-use previous password." },
+            }
+          : { rootError: JSON.stringify(updateResp.error) },
     };
   } else {
     return { lastInvocationStatus: "success" };


### PR DESCRIPTION
Improves UX by adding a field error message for users who attempt to reset their password to their current password.

This corresponds to the supabase auth `same_password` error code.